### PR TITLE
fix: oauthScopes からスタンドアロン非対応スコープを削除

### DIFF
--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -3,9 +3,8 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
-    "https://www.googleapis.com/auth/script.container.ui",
     "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/script.external_request"
+    "https://www.googleapis.com/auth/drive.file"
   ],
   "webapp": {
     "access": "ANYONE",


### PR DESCRIPTION
## 問題

`appsscript.json` に `script.container.ui`（コンテナバインド専用）と `script.external_request`（未使用）が含まれており、スタンドアロン Web App での OAuth 認証フローを壊していた可能性がある。

## 変更内容

| スコープ | 変更 | 理由 |
|---|---|---|
| `script.container.ui` | 削除 | スタンドアロンスクリプトには適用不可 |
| `script.external_request` | 削除 | UrlFetchApp 未使用 |
| `drive.file` | 追加 | `SpreadsheetApp.create()` に必要 |

## 注意

マージ後、スクリプトオーナーが Apps Script エディタで関数を1度実行して新スコープの再認証を行う必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)